### PR TITLE
Re-used installer package ID from Stratis Core

### DIFF
--- a/FullNode.UI/electron-builder.json
+++ b/FullNode.UI/electron-builder.json
@@ -35,7 +35,7 @@
     "perMachine": true,
     "allowToChangeInstallationDirectory": true,
     "deleteAppDataOnUninstall": true,
-    "guid": "ef77eb40-01cf-4516-9da6-f3c6ba6854aa",
+    "guid": "56cbbab3-415f-42b7-b43a-7e3a9036cd36",
     "createDesktopShortcut": true,
     "createStartMenuShortcut": true,
     "license": "src/assets/images/license_en.txt"


### PR DESCRIPTION
- Reusing the same package ID, means that running the installer on a machine that already have Stratis Core installed, it will default to the existing installation folder.
- Running this installer, probably uninstalls Stratis Core for a user. It is not possible to run both X42 and Stratis Core on the same computer, as either installer will uninstall the other app.
- Closes #13